### PR TITLE
[FE-#11] 내가 쓴 리뷰 조회 API 구현

### DIFF
--- a/src/main/java/com/yong2gether/ywave/mypage/controller/MyPageReviewController.java
+++ b/src/main/java/com/yong2gether/ywave/mypage/controller/MyPageReviewController.java
@@ -1,0 +1,64 @@
+// src/main/java/com/yong2gether/ywave/mypage/controller/MyPageReviewController.java
+// 토큰 이메일 -> User.Id 조회 -> path의 {userId}와 일치할때만 가능
+// 실제 데이터는 ReviewQueryService 호출
+package com.yong2gether.ywave.mypage.controller;
+
+import com.yong2gether.ywave.mypage.dto.UserReviewsResponse;
+import com.yong2gether.ywave.mypage.dto.ReviewItemDto;
+import com.yong2gether.ywave.mypage.service.ReviewQueryService;
+import com.yong2gether.ywave.user.domain.User;
+import com.yong2gether.ywave.user.repository.UserRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.*;
+import io.swagger.v3.oas.annotations.responses.*;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.*;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/mypage")
+public class MyPageReviewController {
+
+    private final ReviewQueryService reviewQueryService;
+    private final UserRepository userRepository;
+
+    @Operation(
+            summary = "내가 쓴 리뷰 조회",
+            description = "userId 기준으로 해당 사용자가 작성한 모든 리뷰를 조회(디폴트:최신순)합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = UserReviewsResponse.class))),
+            @ApiResponse(responseCode = "403", description = "권한 없음")
+    })
+    @GetMapping("/{userId}/reviews") // API URL : GET /api/v1/mypage/{userId}/reviews
+    public ResponseEntity<UserReviewsResponse> getMyReviews(
+            @Parameter(description = "사용자 ID", example = "1")
+            @PathVariable Long userId) {
+
+        // ★ 토큰(이메일)로 본인 확인
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || auth.getPrincipal() == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        String email = auth.getName(); // JwtFilter에서 principal로 넣은 값(이메일)
+
+        User me = userRepository.findByEmail(email)
+                .orElse(null);
+        if (me == null || !me.getId().equals(userId)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+
+        List<ReviewItemDto> items = reviewQueryService.getUserReviews(userId);
+        return ResponseEntity.ok(
+                new UserReviewsResponse("사용자가 작성한 리뷰 목록 조회에 성공했습니다.", items)
+        );
+    }
+}

--- a/src/main/java/com/yong2gether/ywave/mypage/dto/ReviewItemDto.java
+++ b/src/main/java/com/yong2gether/ywave/mypage/dto/ReviewItemDto.java
@@ -1,0 +1,31 @@
+// src/main/java/com/yong2gether/ywave/mypage/dto/ReviewItemDto.java
+package com.yong2gether.ywave.mypage.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.yong2gether.ywave.review.repository.projection.ReviewListItemView;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+@Schema(name = "ReviewItem")
+public record ReviewItemDto(
+        @Schema(example = "1") Long reviewId,
+        @Schema(example = "s101") String storeId,
+        @Schema(example = "스타벅스") String storeName,
+        @Schema(example = "커피 맛집!") String content,
+        @Schema(example = "4.5") Double rating,
+        @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")          // API 명세서와 동일
+        @Schema(example = "2025-08-04T14:21:00")
+        LocalDateTime createdAt
+) {
+    public static ReviewItemDto from(ReviewListItemView v) {
+        return new ReviewItemDto(
+                v.getReviewId(),
+                v.getStoreId(),
+                v.getStoreName(),
+                v.getContent(),
+                v.getRating(),
+                v.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/yong2gether/ywave/mypage/dto/UserReviewsResponse.java
+++ b/src/main/java/com/yong2gether/ywave/mypage/dto/UserReviewsResponse.java
@@ -1,0 +1,12 @@
+package com.yong2gether.ywave.mypage.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(name = "UserReviewsResponse")
+public record UserReviewsResponse(
+        @Schema(example = "사용자가 작성한 리뷰 목록 조회에 성공했습니다.")
+        String message,
+        List<ReviewItemDto> reviews
+) {}

--- a/src/main/java/com/yong2gether/ywave/mypage/service/ReviewQueryService.java
+++ b/src/main/java/com/yong2gether/ywave/mypage/service/ReviewQueryService.java
@@ -1,0 +1,19 @@
+package com.yong2gether.ywave.mypage.service;
+
+import com.yong2gether.ywave.mypage.dto.ReviewItemDto;
+import com.yong2gether.ywave.review.repository.ReviewRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewQueryService {
+    private final ReviewRepository reviewRepository;
+
+    public List<ReviewItemDto> getUserReviews(Long userId) {
+        return reviewRepository.findAllByUserId(userId)
+                .stream().map(ReviewItemDto::from).toList();
+    }
+}

--- a/src/main/java/com/yong2gether/ywave/review/domain/Review.java
+++ b/src/main/java/com/yong2gether/ywave/review/domain/Review.java
@@ -1,0 +1,28 @@
+package com.yong2gether.ywave.review.domain;
+
+import com.yong2gether.ywave.global.domain.BaseTime;
+import com.yong2gether.ywave.store.domain.Store;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "review")
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+public class Review extends BaseTime { // BaseTime 상속 -> created_at(생성일), updated_at(수정일) 자동 세팅
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // 리뷰 pk
+
+    @Column(name="user_id", nullable = false)
+    private Long userId; // 작성자 유저 PK : "내"가 쓴 리뷰
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="store_id", nullable = false)
+    private Store store;
+
+    @Column(nullable = false, length = 1000)
+    private String content; // 리뷰 내용
+
+    @Column(nullable = false)
+    private Double rating; // 별점
+}

--- a/src/main/java/com/yong2gether/ywave/review/repository/ReviewRepository.java
+++ b/src/main/java/com/yong2gether/ywave/review/repository/ReviewRepository.java
@@ -1,0 +1,26 @@
+package com.yong2gether.ywave.review.repository;
+
+import com.yong2gether.ywave.review.domain.Review;
+import com.yong2gether.ywave.review.repository.projection.ReviewListItemView;
+import org.springframework.data.jpa.repository.*;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+
+    @Query("""
+        select 
+            r.id as reviewId,
+            s.id as storeId,
+            s.name as storeName,
+            r.content as content,
+            r.rating as rating,
+            r.createdAt as createdAt
+        from Review r
+        join r.store s
+        where r.userId = :userId
+        order by r.createdAt desc
+    """)
+    List<ReviewListItemView> findAllByUserId(@Param("userId") Long userId);
+}

--- a/src/main/java/com/yong2gether/ywave/review/repository/projection/ReviewListItemView.java
+++ b/src/main/java/com/yong2gether/ywave/review/repository/projection/ReviewListItemView.java
@@ -1,0 +1,12 @@
+package com.yong2gether.ywave.review.repository.projection;
+
+import java.time.LocalDateTime;
+
+public interface ReviewListItemView {
+    Long getReviewId();
+    String getStoreId();
+    String getStoreName();
+    String getContent();
+    Double getRating();
+    LocalDateTime getCreatedAt();
+}

--- a/src/main/java/com/yong2gether/ywave/store/domain/Store.java
+++ b/src/main/java/com/yong2gether/ywave/store/domain/Store.java
@@ -1,0 +1,17 @@
+package com.yong2gether.ywave.store.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+// store 테이블과 매핑
+@Entity
+@Table(name = "store")
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+public class Store {
+    @Id
+    @Column(length = 32)
+    private String id; // pk, 가맹점 ID (예: s101)
+
+    @Column(nullable = false, length = 100) // Column 세부 설정
+    private String name;
+}


### PR DESCRIPTION
## 🛰️ Issue Number
- #11 
## 🪐 작업 내용
### 1️⃣ Repository
-  `ReviewListItemView` Projection 생성  
   - 리뷰 목록 조회 시 필요한 필드만 가져오기 위한 인터페이스 정의
### 2️⃣ DTO
 - `ReviewItemDto` 생성 
    -  Projection 결과를 DTO로 변환해 API 응답에 맞는 구조 제공
- `reviewId` → `Long` 타입 사용, `createdAt` 은 `LocalDateTime` + `@JsonFormat` 으로 응답 형식 고정
- `createdAt` 필드는 `BaseTimeEntity` 를 상속받아 JPA Auditing 에 의해 자동 설정되도록 구현됨
### 3️⃣ Service
- `MyPageService` 내 `getUserReviews(Long userId)` 메서드 구현 
   - userId 기준으로 작성 리뷰 목록을 최신순으로 조회 후 DTO 리스트로 매핑
### 4️⃣ Controller
- `MyPageController` 에 `/mypage/reviews` API 추가  
   - 로그인된 사용자(userId) 기반으로 내가 작성한 리뷰 목록을 조회
   - Swagger 명세서에 `"사용자가 작성한 리뷰 목록 조회에 성공했습니다."` 문구와 응답 예시 추가  
### 5️⃣ Swagger Test 방식
- 리뷰 생성 기능이 없어서 DB에 임시 데이터를 넣어서 test 실행
#### 1. 본인이 쓴 리뷰를 조회했을 때 (현재 사용자 id = 1, id 일치)
<img width="1300" height="614" alt="스크린샷 2025-08-18 오전 3 49 01" src="https://github.com/user-attachments/assets/305e541c-88bc-4d15-91f0-e63c2eeafc12" />
<img width="1205" height="655" alt="스크린샷 2025-08-18 오전 3 49 14" src="https://github.com/user-attachments/assets/30bc3926-735c-4478-ad06-a0a53555a4ef" />

#### 2. 본인이 쓰지 않은 리뷰를 조회했을 때 (현재 사용자 id = 1, id 불일치)
<img width="1246" height="827" alt="스크린샷 2025-08-18 오전 3 49 28" src="https://github.com/user-attachments/assets/675b2889-7970-4988-8b1a-b0151bd4226a" />


## 📚 Reference
내가 쓴 리뷰 조회 API 명세서
- 각 필드의 타입 명시함
- https://www.notion.so/hufsglobal/24482a1df32180a6974ccfa8fd3a7bdd
## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

