### PR TITLE
Refactor/be 38/get bookmark

### DIFF
--- a/src/main/java/com/yong2gether/ywave/bookmark/domain/Bookmark.java
+++ b/src/main/java/com/yong2gether/ywave/bookmark/domain/Bookmark.java
@@ -1,0 +1,35 @@
+package com.yong2gether.ywave.bookmark.domain;
+
+import com.yong2gether.ywave.global.domain.BaseTime;
+import com.yong2gether.ywave.store.domain.Store;
+import com.yong2gether.ywave.user.domain.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "bookmark", schema = "core")
+public class Bookmark extends BaseTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "bookmark_group_id", nullable = false)
+    private BookmarkGroup group;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id", nullable = false)
+    private Store store;
+}
+
+

--- a/src/main/java/com/yong2gether/ywave/bookmark/domain/BookmarkGroup.java
+++ b/src/main/java/com/yong2gether/ywave/bookmark/domain/BookmarkGroup.java
@@ -1,0 +1,33 @@
+package com.yong2gether.ywave.bookmark.domain;
+
+import com.yong2gether.ywave.global.domain.BaseTime;
+import com.yong2gether.ywave.user.domain.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "bookmark_group", schema = "core")
+public class BookmarkGroup extends BaseTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Builder.Default
+    @Column(name = "is_default", nullable = false)
+    private boolean isDefault = false;
+}
+
+

--- a/src/main/java/com/yong2gether/ywave/bookmark/repository/BookmarkGroupRepository.java
+++ b/src/main/java/com/yong2gether/ywave/bookmark/repository/BookmarkGroupRepository.java
@@ -1,0 +1,11 @@
+// src/main/java/com/yong2gether/ywave/bookmark/repository/BookmarkGroupRepository.java
+package com.yong2gether.ywave.bookmark.repository;
+
+import com.yong2gether.ywave.bookmark.domain.BookmarkGroup;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface BookmarkGroupRepository extends JpaRepository<BookmarkGroup, Long> {
+    Optional<BookmarkGroup> findByUserIdAndIsDefaultTrue(Long userId);
+}

--- a/src/main/java/com/yong2gether/ywave/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/com/yong2gether/ywave/bookmark/repository/BookmarkRepository.java
@@ -11,25 +11,35 @@ import java.util.List;
 // src/main/java/com/yong2gether/ywave/bookmark/repository/BookmarkRepository.java
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
 
-    @Query("""
+    @Query(value = """
       select
-        g.id as groupId,
-        g.name as groupName,
-        g.isDefault as isDefault,
-        s.id as storeId,
-        s.name as storeName,
-        s.category as category,
-        s.roadAddress as roadAddress,
-        s.lat as lat,
-        s.lng as lng,
-        s.phone as phone,
-        s.rating as rating,
-        s.reviewCount as reviewCount
-      from BookmarkGroup g
-        left join Bookmark b on b.group = g       
-        left join b.store s                    
-      where g.user.id = :userId
-      order by g.isDefault desc, g.name asc, s.name asc
-    """)
+        g.id                              as groupId,
+        g.name                            as groupName,
+        g.is_default                      as isDefault,
+        s.id                              as storeId,
+        s.name                            as storeName,
+        (
+          select string_agg(distinct c.name, ',')
+          from core.store_category sc
+          join core.category c on c.id = sc.category_id
+          where sc.store_id = s.id
+        )                                  as category,
+        coalesce(s.road_addr, s.lotno_addr) as roadAddress,
+        case when s.geom is not null then ST_Y(s.geom) else null end as lat,
+        case when s.geom is not null then ST_X(s.geom) else null end as lng,
+        s.phone                           as phone,
+        coalesce(s.thumbnail_url, '')     as thumbnailUrl,
+        cast(null as float8)              as rating,
+        cast(null as int)                 as reviewCount
+      from core.bookmark_group g
+        left join core.bookmark b on b.bookmark_group_id = g.id
+        left join core.stores   s on s.id = b.store_id
+      where g.user_id = :userId
+      order by 
+        g.is_default desc,           -- 기본 그룹 우선
+        g.created_at asc,            -- 그 외 그룹은 생성순
+        b.created_at desc nulls last,-- 그룹 내 매장은 최신 북마크순
+        s.name asc                   -- 동순위 보정
+    """, nativeQuery = true)
     List<BookmarkFlatView> findAllGroupsWithStores(@Param("userId") Long userId);
 }

--- a/src/main/java/com/yong2gether/ywave/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/com/yong2gether/ywave/bookmark/repository/BookmarkRepository.java
@@ -1,0 +1,35 @@
+// src/main/java/com/yong2gether/ywave/bookmark/repository/BookmarkRepository.java
+package com.yong2gether.ywave.bookmark.repository;
+
+import com.yong2gether.ywave.bookmark.domain.Bookmark;
+import com.yong2gether.ywave.bookmark.repository.projection.BookmarkFlatView;
+import org.springframework.data.jpa.repository.*;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+// src/main/java/com/yong2gether/ywave/bookmark/repository/BookmarkRepository.java
+public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
+
+    @Query("""
+      select
+        g.id as groupId,
+        g.name as groupName,
+        g.isDefault as isDefault,
+        s.id as storeId,
+        s.name as storeName,
+        s.category as category,
+        s.roadAddress as roadAddress,
+        s.lat as lat,
+        s.lng as lng,
+        s.phone as phone,
+        s.rating as rating,
+        s.reviewCount as reviewCount
+      from BookmarkGroup g
+        left join Bookmark b on b.group = g       
+        left join b.store s                    
+      where g.user.id = :userId
+      order by g.isDefault desc, g.name asc, s.name asc
+    """)
+    List<BookmarkFlatView> findAllGroupsWithStores(@Param("userId") Long userId);
+}

--- a/src/main/java/com/yong2gether/ywave/bookmark/repository/projection/BookmarkFlatView.java
+++ b/src/main/java/com/yong2gether/ywave/bookmark/repository/projection/BookmarkFlatView.java
@@ -1,0 +1,23 @@
+package com.yong2gether.ywave.bookmark.repository.projection;
+
+public interface BookmarkFlatView {
+    Long getGroupId();
+    String getGroupName();
+    Boolean getIsDefault();
+
+    Long getStoreId();
+    String getStoreName();
+
+    // 아래 필드들은 현재 Store 엔티티와 다를 수 있으므로
+    // 쿼리에서 null이 되더라도 컴파일은 가능하도록 유지합니다.
+    String getCategory();
+    String getRoadAddress();
+    Double getLat();
+    Double getLng();
+    String getPhone();
+    Double getRating();
+    Integer getReviewCount();
+    String getThumbnailUrl();
+}
+
+

--- a/src/main/java/com/yong2gether/ywave/global/config/SecurityConfig.java
+++ b/src/main/java/com/yong2gether/ywave/global/config/SecurityConfig.java
@@ -30,6 +30,7 @@ import java.util.List;
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
+@org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity(prePostEnabled = true)
 public class SecurityConfig {
 
     private final AuthenticationConfiguration authenticationConfiguration;

--- a/src/main/java/com/yong2gether/ywave/global/security/Authz.java
+++ b/src/main/java/com/yong2gether/ywave/global/security/Authz.java
@@ -1,0 +1,30 @@
+package com.yong2gether.ywave.global.security;
+
+import com.yong2gether.ywave.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+@Component("authz")
+@RequiredArgsConstructor
+public class Authz {
+
+    private final UserRepository userRepository;
+
+
+    public boolean isSelfOrAdmin(Long userId, Authentication auth) {
+        if (auth == null || !auth.isAuthenticated()) return false;
+
+        boolean isAdmin = auth.getAuthorities().stream()
+                .anyMatch(a -> "ROLE_ADMIN".equals(a.getAuthority()));
+        if (isAdmin) return true;
+
+
+        String email = auth.getName();
+        if (email == null) return false;
+
+        return userRepository.findByEmail(email)
+                .map(u -> u.getId().equals(userId))
+                .orElse(false);
+    }
+}

--- a/src/main/java/com/yong2gether/ywave/mypage/controller/BookmarkQueryController.java
+++ b/src/main/java/com/yong2gether/ywave/mypage/controller/BookmarkQueryController.java
@@ -1,0 +1,36 @@
+// src/main/java/com/yong2gether/ywave/mypage/controller/BookmarkQueryController.java
+package com.yong2gether.ywave.mypage.controller;
+
+import com.yong2gether.ywave.mypage.dto.*;
+import com.yong2gether.ywave.mypage.service.BookmarkQueryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/mypage")
+public class BookmarkQueryController {
+
+    private final BookmarkQueryService bookmarkQueryService;
+
+    @Operation(summary="북마크한 가맹점 그룹별 조회",
+            description="특정 사용자의 북마크한 가맹점을 그룹 단위로 조회합니다.(default: 기본그룹)")
+    @ApiResponses({
+            @ApiResponse(responseCode="200", description="조회 성공"),
+            @ApiResponse(responseCode="403", description="권한 없음")
+    })
+    @GetMapping("/{userId}/bookmarks/groups")
+    @PreAuthorize("@authz.isSelfOrAdmin(#userId, authentication)")
+    public ResponseEntity<BookmarkedGroupsResponse> getBookmarkedGroups(
+            @PathVariable Long userId
+    ) {
+        List<BookmarkGroupDto> groups = bookmarkQueryService.getBookmarkedGroups(userId);
+        return ResponseEntity.ok(BookmarkedGroupsResponse.ok(groups));
+    }
+}

--- a/src/main/java/com/yong2gether/ywave/mypage/controller/BookmarkQueryController.java
+++ b/src/main/java/com/yong2gether/ywave/mypage/controller/BookmarkQueryController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.responses.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -28,8 +29,10 @@ public class BookmarkQueryController {
     @GetMapping("/{userId}/bookmarks/groups")
     @PreAuthorize("@authz.isSelfOrAdmin(#userId, authentication)")
     public ResponseEntity<BookmarkedGroupsResponse> getBookmarkedGroups(
-            @PathVariable Long userId
+            @PathVariable Long userId,
+            Authentication authentication
     ) {
+        System.out.println("[DEBUG] bookmarks principal=" + (authentication != null ? authentication.getName() : null) + ", userId=" + userId);
         List<BookmarkGroupDto> groups = bookmarkQueryService.getBookmarkedGroups(userId);
         return ResponseEntity.ok(BookmarkedGroupsResponse.ok(groups));
     }

--- a/src/main/java/com/yong2gether/ywave/mypage/controller/MyPageReviewController.java
+++ b/src/main/java/com/yong2gether/ywave/mypage/controller/MyPageReviewController.java
@@ -14,8 +14,8 @@ import io.swagger.v3.oas.annotations.responses.*;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.*;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -26,7 +26,6 @@ import java.util.List;
 public class MyPageReviewController {
 
     private final ReviewQueryService reviewQueryService;
-    private final UserRepository userRepository;
 
     @Operation(
             summary = "내가 쓴 리뷰 조회",
@@ -39,23 +38,12 @@ public class MyPageReviewController {
             @ApiResponse(responseCode = "403", description = "권한 없음")
     })
     @GetMapping("/{userId}/reviews") // API URL : GET /api/v1/mypage/{userId}/reviews
+    @PreAuthorize("@authz.isSelfOrAdmin(#userId, authentication)")
     public ResponseEntity<UserReviewsResponse> getMyReviews(
             @Parameter(description = "사용자 ID", example = "1")
-            @PathVariable Long userId) {
-
-        // ★ 토큰(이메일)로 본인 확인
-        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        if (auth == null || auth.getPrincipal() == null) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
-        }
-        String email = auth.getName(); // JwtFilter에서 principal로 넣은 값(이메일)
-
-        User me = userRepository.findByEmail(email)
-                .orElse(null);
-        if (me == null || !me.getId().equals(userId)) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
-        }
-
+            @PathVariable Long userId,
+            Authentication authentication) {
+        System.out.println("[DEBUG] reviews principal=" + (authentication != null ? authentication.getName() : null) + ", userId=" + userId);
         List<ReviewItemDto> items = reviewQueryService.getUserReviews(userId);
         return ResponseEntity.ok(
                 new UserReviewsResponse("사용자가 작성한 리뷰 목록 조회에 성공했습니다.", items)

--- a/src/main/java/com/yong2gether/ywave/mypage/controller/MyPageReviewController.java
+++ b/src/main/java/com/yong2gether/ywave/mypage/controller/MyPageReviewController.java
@@ -1,0 +1,64 @@
+// src/main/java/com/yong2gether/ywave/mypage/controller/MyPageReviewController.java
+// 토큰 이메일 -> User.Id 조회 -> path의 {userId}와 일치할때만 가능
+// 실제 데이터는 ReviewQueryService 호출
+package com.yong2gether.ywave.mypage.controller;
+
+import com.yong2gether.ywave.mypage.dto.UserReviewsResponse;
+import com.yong2gether.ywave.mypage.dto.ReviewItemDto;
+import com.yong2gether.ywave.mypage.service.ReviewQueryService;
+import com.yong2gether.ywave.user.domain.User;
+import com.yong2gether.ywave.user.repository.UserRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.*;
+import io.swagger.v3.oas.annotations.responses.*;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.*;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/mypage")
+public class MyPageReviewController {
+
+    private final ReviewQueryService reviewQueryService;
+    private final UserRepository userRepository;
+
+    @Operation(
+            summary = "내가 쓴 리뷰 조회",
+            description = "userId 기준으로 해당 사용자가 작성한 모든 리뷰를 조회(디폴트:최신순)합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = UserReviewsResponse.class))),
+            @ApiResponse(responseCode = "403", description = "권한 없음")
+    })
+    @GetMapping("/{userId}/reviews") // API URL : GET /api/v1/mypage/{userId}/reviews
+    public ResponseEntity<UserReviewsResponse> getMyReviews(
+            @Parameter(description = "사용자 ID", example = "1")
+            @PathVariable Long userId) {
+
+        // ★ 토큰(이메일)로 본인 확인
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || auth.getPrincipal() == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        String email = auth.getName(); // JwtFilter에서 principal로 넣은 값(이메일)
+
+        User me = userRepository.findByEmail(email)
+                .orElse(null);
+        if (me == null || !me.getId().equals(userId)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+
+        List<ReviewItemDto> items = reviewQueryService.getUserReviews(userId);
+        return ResponseEntity.ok(
+                new UserReviewsResponse("사용자가 작성한 리뷰 목록 조회에 성공했습니다.", items)
+        );
+    }
+}

--- a/src/main/java/com/yong2gether/ywave/mypage/dto/BookmarkGroupDto.java
+++ b/src/main/java/com/yong2gether/ywave/mypage/dto/BookmarkGroupDto.java
@@ -1,0 +1,11 @@
+// src/main/java/com/yong2gether/ywave/mypage/dto/BookmarkGroupDto.java
+package com.yong2gether.ywave.mypage.dto;
+
+import java.util.List;
+
+public record BookmarkGroupDto(
+        Long groupId,
+        String groupName,
+        boolean isDefault,
+        List<BookmarkedStoreDto> stores
+) {}

--- a/src/main/java/com/yong2gether/ywave/mypage/dto/BookmarkedGroupsResponse.java
+++ b/src/main/java/com/yong2gether/ywave/mypage/dto/BookmarkedGroupsResponse.java
@@ -1,0 +1,13 @@
+// src/main/java/com/yong2gether/ywave/mypage/dto/BookmarkedGroupsResponse.java
+package com.yong2gether.ywave.mypage.dto;
+
+import java.util.List;
+
+public record BookmarkedGroupsResponse(
+        String message,
+        List<BookmarkGroupDto> groups
+) {
+    public static BookmarkedGroupsResponse ok(List<BookmarkGroupDto> groups) {
+        return new BookmarkedGroupsResponse("북마크한 가맹점 목록 조회 성공", groups);
+    }
+}

--- a/src/main/java/com/yong2gether/ywave/mypage/dto/BookmarkedStoreDto.java
+++ b/src/main/java/com/yong2gether/ywave/mypage/dto/BookmarkedStoreDto.java
@@ -2,7 +2,7 @@
 package com.yong2gether.ywave.mypage.dto;
 
 public record BookmarkedStoreDto(
-        String storeId,
+        Long storeId,
         String storeName,
         String category,
         String roadAddress,
@@ -10,6 +10,6 @@ public record BookmarkedStoreDto(
         Double lng,
         String phone,
         Double rating,
-        Integer reviewCount
-        /*String thumbnailUrl*/
+        Integer reviewCount,
+        String thumbnailUrl
 ) {}

--- a/src/main/java/com/yong2gether/ywave/mypage/dto/BookmarkedStoreDto.java
+++ b/src/main/java/com/yong2gether/ywave/mypage/dto/BookmarkedStoreDto.java
@@ -1,0 +1,15 @@
+// src/main/java/com/yong2gether/ywave/mypage/dto/BookmarkedStoreDto.java
+package com.yong2gether.ywave.mypage.dto;
+
+public record BookmarkedStoreDto(
+        String storeId,
+        String storeName,
+        String category,
+        String roadAddress,
+        Double lat,
+        Double lng,
+        String phone,
+        Double rating,
+        Integer reviewCount
+        /*String thumbnailUrl*/
+) {}

--- a/src/main/java/com/yong2gether/ywave/mypage/dto/ReviewItemDto.java
+++ b/src/main/java/com/yong2gether/ywave/mypage/dto/ReviewItemDto.java
@@ -1,0 +1,31 @@
+// src/main/java/com/yong2gether/ywave/mypage/dto/ReviewItemDto.java
+package com.yong2gether.ywave.mypage.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.yong2gether.ywave.review.repository.projection.ReviewListItemView;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+@Schema(name = "ReviewItem")
+public record ReviewItemDto(
+        @Schema(example = "1") Long reviewId,
+        @Schema(example = "s101") String storeId,
+        @Schema(example = "스타벅스") String storeName,
+        @Schema(example = "커피 맛집!") String content,
+        @Schema(example = "4.5") Double rating,
+        @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")          // API 명세서와 동일
+        @Schema(example = "2025-08-04T14:21:00")
+        LocalDateTime createdAt
+) {
+    public static ReviewItemDto from(ReviewListItemView v) {
+        return new ReviewItemDto(
+                v.getReviewId(),
+                v.getStoreId(),
+                v.getStoreName(),
+                v.getContent(),
+                v.getRating(),
+                v.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/yong2gether/ywave/mypage/dto/ReviewItemDto.java
+++ b/src/main/java/com/yong2gether/ywave/mypage/dto/ReviewItemDto.java
@@ -10,7 +10,7 @@ import java.time.LocalDateTime;
 @Schema(name = "ReviewItem")
 public record ReviewItemDto(
         @Schema(example = "1") Long reviewId,
-        @Schema(example = "s101") String storeId,
+        @Schema(example = "123") Long storeId,
         @Schema(example = "스타벅스") String storeName,
         @Schema(example = "커피 맛집!") String content,
         @Schema(example = "4.5") Double rating,

--- a/src/main/java/com/yong2gether/ywave/mypage/dto/UserReviewsResponse.java
+++ b/src/main/java/com/yong2gether/ywave/mypage/dto/UserReviewsResponse.java
@@ -1,0 +1,12 @@
+package com.yong2gether.ywave.mypage.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(name = "UserReviewsResponse")
+public record UserReviewsResponse(
+        @Schema(example = "사용자가 작성한 리뷰 목록 조회에 성공했습니다.")
+        String message,
+        List<ReviewItemDto> reviews
+) {}

--- a/src/main/java/com/yong2gether/ywave/mypage/service/BookmarkGroupCommandService.java
+++ b/src/main/java/com/yong2gether/ywave/mypage/service/BookmarkGroupCommandService.java
@@ -1,0 +1,31 @@
+// src/main/java/com/yong2gether/ywave/bookmark/service/BookmarkGroupCommandService.java
+package com.yong2gether.ywave.mypage.service;
+
+import com.yong2gether.ywave.bookmark.domain.BookmarkGroup;
+import com.yong2gether.ywave.bookmark.repository.BookmarkGroupRepository;
+import com.yong2gether.ywave.user.domain.User;
+import com.yong2gether.ywave.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service @RequiredArgsConstructor
+public class BookmarkGroupCommandService {
+
+    private final BookmarkGroupRepository groupRepo;
+    private final UserRepository userRepo;
+
+    @Transactional
+    public BookmarkGroup ensureDefaultGroup(Long userId) {
+        return groupRepo.findByUserIdAndIsDefaultTrue(userId)
+                .orElseGet(() -> {
+                    User user = userRepo.getReferenceById(userId);
+                    BookmarkGroup g = BookmarkGroup.builder()
+                            .user(user)
+                            .name("기본 그룹")
+                            .isDefault(true)
+                            .build();
+                    return groupRepo.save(g);
+                });
+    }
+}

--- a/src/main/java/com/yong2gether/ywave/mypage/service/BookmarkQueryService.java
+++ b/src/main/java/com/yong2gether/ywave/mypage/service/BookmarkQueryService.java
@@ -1,0 +1,61 @@
+// src/main/java/com/yong2gether/ywave/mypage/service/BookmarkQueryService.java
+package com.yong2gether.ywave.mypage.service;
+
+import com.yong2gether.ywave.bookmark.domain.BookmarkGroup;
+import com.yong2gether.ywave.bookmark.repository.BookmarkRepository;
+import com.yong2gether.ywave.bookmark.repository.projection.BookmarkFlatView;
+import com.yong2gether.ywave.mypage.dto.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BookmarkQueryService {
+
+    private final BookmarkRepository bookmarkRepository;
+    private final BookmarkGroupCommandService bookmarkGroupCommandService;
+
+    @Transactional // 메서드 단위로 write 허용
+    public List<BookmarkGroupDto> getBookmarkedGroups(Long userId) {
+        // 1) 기본 그룹 보장하고, 그 엔티티를 받아둔다
+        BookmarkGroup defaultGroup = bookmarkGroupCommandService.ensureDefaultGroup(userId);
+
+        // 2) 모든 그룹(빈 그룹 포함) 조회
+        List<BookmarkFlatView> rows = bookmarkRepository.findAllGroupsWithStores(userId);
+
+        // 3) 혹시라도 0건이면(예: 잘못된 JOIN/신규 사용자) 기본 그룹만 내려준다
+        if (rows.isEmpty()) {
+            return List.of(new BookmarkGroupDto(
+                    defaultGroup.getId(),
+                    defaultGroup.getName(),
+                    defaultGroup.isDefault(),
+                    new ArrayList<>()
+            ));
+        }
+
+        // 4) 결과 그룹핑
+        Map<Long, BookmarkGroupDto> map = new LinkedHashMap<>();
+        for (BookmarkFlatView r : rows) {
+            BookmarkGroupDto groupDto = map.computeIfAbsent(
+                    r.getGroupId(),
+                    id -> new BookmarkGroupDto(
+                            r.getGroupId(),
+                            r.getGroupName(),
+                            Boolean.TRUE.equals(r.getIsDefault()),
+                            new ArrayList<>()
+                    )
+            );
+            if (r.getStoreId() != null) {
+                groupDto.stores().add(new BookmarkedStoreDto(
+                        r.getStoreId(), r.getStoreName(), r.getCategory(), r.getRoadAddress(),
+                        r.getLat(), r.getLng(), r.getPhone(), r.getRating(), r.getReviewCount()
+                ));
+            }
+        }
+        return new ArrayList<>(map.values());
+    }
+}

--- a/src/main/java/com/yong2gether/ywave/mypage/service/BookmarkQueryService.java
+++ b/src/main/java/com/yong2gether/ywave/mypage/service/BookmarkQueryService.java
@@ -52,7 +52,7 @@ public class BookmarkQueryService {
             if (r.getStoreId() != null) {
                 groupDto.stores().add(new BookmarkedStoreDto(
                         r.getStoreId(), r.getStoreName(), r.getCategory(), r.getRoadAddress(),
-                        r.getLat(), r.getLng(), r.getPhone(), r.getRating(), r.getReviewCount()
+                        r.getLat(), r.getLng(), r.getPhone(), r.getRating(), r.getReviewCount(), r.getThumbnailUrl()
                 ));
             }
         }

--- a/src/main/java/com/yong2gether/ywave/mypage/service/ReviewQueryService.java
+++ b/src/main/java/com/yong2gether/ywave/mypage/service/ReviewQueryService.java
@@ -1,0 +1,19 @@
+package com.yong2gether.ywave.mypage.service;
+
+import com.yong2gether.ywave.mypage.dto.ReviewItemDto;
+import com.yong2gether.ywave.review.repository.ReviewRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewQueryService {
+    private final ReviewRepository reviewRepository;
+
+    public List<ReviewItemDto> getUserReviews(Long userId) {
+        return reviewRepository.findAllByUserId(userId)
+                .stream().map(ReviewItemDto::from).toList();
+    }
+}

--- a/src/main/java/com/yong2gether/ywave/review/domain/Review.java
+++ b/src/main/java/com/yong2gether/ywave/review/domain/Review.java
@@ -1,0 +1,28 @@
+package com.yong2gether.ywave.review.domain;
+
+import com.yong2gether.ywave.global.domain.BaseTime;
+import com.yong2gether.ywave.store.domain.Store;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "review")
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+public class Review extends BaseTime { // BaseTime 상속 -> created_at(생성일), updated_at(수정일) 자동 세팅
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // 리뷰 pk
+
+    @Column(name="user_id", nullable = false)
+    private Long userId; // 작성자 유저 PK : "내"가 쓴 리뷰
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="store_id", nullable = false)
+    private Store store;
+
+    @Column(nullable = false, length = 1000)
+    private String content; // 리뷰 내용
+
+    @Column(nullable = false)
+    private Double rating; // 별점
+}

--- a/src/main/java/com/yong2gether/ywave/review/repository/ReviewRepository.java
+++ b/src/main/java/com/yong2gether/ywave/review/repository/ReviewRepository.java
@@ -1,0 +1,26 @@
+package com.yong2gether.ywave.review.repository;
+
+import com.yong2gether.ywave.review.domain.Review;
+import com.yong2gether.ywave.review.repository.projection.ReviewListItemView;
+import org.springframework.data.jpa.repository.*;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+
+    @Query("""
+        select 
+            r.id as reviewId,
+            s.id as storeId,
+            s.name as storeName,
+            r.content as content,
+            r.rating as rating,
+            r.createdAt as createdAt
+        from Review r
+        join r.store s
+        where r.userId = :userId
+        order by r.createdAt desc
+    """)
+    List<ReviewListItemView> findAllByUserId(@Param("userId") Long userId);
+}

--- a/src/main/java/com/yong2gether/ywave/review/repository/projection/ReviewListItemView.java
+++ b/src/main/java/com/yong2gether/ywave/review/repository/projection/ReviewListItemView.java
@@ -1,0 +1,12 @@
+package com.yong2gether.ywave.review.repository.projection;
+
+import java.time.LocalDateTime;
+
+public interface ReviewListItemView {
+    Long getReviewId();
+    String getStoreId();
+    String getStoreName();
+    String getContent();
+    Double getRating();
+    LocalDateTime getCreatedAt();
+}

--- a/src/main/java/com/yong2gether/ywave/review/repository/projection/ReviewListItemView.java
+++ b/src/main/java/com/yong2gether/ywave/review/repository/projection/ReviewListItemView.java
@@ -4,7 +4,7 @@ import java.time.LocalDateTime;
 
 public interface ReviewListItemView {
     Long getReviewId();
-    String getStoreId();
+    Long getStoreId();
     String getStoreName();
     String getContent();
     Double getRating();

--- a/src/main/java/com/yong2gether/ywave/store/domain/Store.java
+++ b/src/main/java/com/yong2gether/ywave/store/domain/Store.java
@@ -47,4 +47,5 @@ public class Store {
     public void setMainPrdRaw(String mainPrdRaw) { this.mainPrdRaw = mainPrdRaw; }
     public Point getGeom() { return geom; }
     public void setGeom(Point geom) { this.geom = geom; }
+
 }


### PR DESCRIPTION
## 🛰️ Issue Number
- #38 

## 🪐 작업 내용
### 1️⃣북마크 조회
  - 카테고리: core.store_category ↔ core.category 조인 후 string_agg(distinct c.name, ',')로 반환
  - 주소: coalesce(s.road_addr, s.lotno_addr)
  - 좌표: ST_Y(s.geom)(lat), ST_X(s.geom)(lng)
  - 썸네일: coalesce(s.thumbnail_url, '')로 기본값 처리
  - 정렬: 기본그룹 우선 → 그룹 생성순(g.created_at asc) → 그룹 내 최신 북마크순(b.created_at desc)
  - 변경 파일: BookmarkRepository.java, BookmarkedStoreDto.java, BookmarkQueryService.java
### 2️⃣ 리뷰 조회
  - 정렬: 최신순(r.createdAt desc)
  - DTO/프로젝션 정합성: ReviewItemDto·ReviewListItemView의 storeId: Long 일치
  - 변경 파일: ReviewRepository.java, ReviewItemDto.java, ReviewListItemView.java
- 컨트롤러/보안
  - @PreAuthorize("@authz.isSelfOrAdmin(#userId, authentication)") 적용/유지
  - 진단 로그 추가: BookmarkQueryController, MyPageReviewController (principal/userId 출력)

3️⃣ 기타
  - 원격 DB 미변경(로컬로만 테스트)

### 1. 내가 쓴 리뷰 조회
<img width="1240" height="377" alt="스크린샷 2025-08-22 오후 7 59 06" src="https://github.com/user-attachments/assets/3a7e78e6-191b-4e43-8f36-13d2fdbdee07" />


### 2. 북마크한 가맹점 그룹별 조회
<img width="1208" height="435" alt="스크린샷 2025-08-22 오후 7 44 13" src="https://github.com/user-attachments/assets/c805ad7d-2ed2-4073-abbb-f414619c0d62" />
<img width="1322" height="243" alt="스크린샷 2025-08-22 오후 7 44 16" src="https://github.com/user-attachments/assets/a2c063e9-64e3-49eb-8ad0-44c97925f8cc" />



## 📚 Reference
- 내가 쓴 리뷰 조회 API 명세서 (수정 완료!)
https://www.notion.so/hufsglobal/24482a1df32180a6974ccfa8fd3a7bdd

- 북마크한 가맹점 그룹별 조회 API 명세서 (수정 완료!)
https://www.notion.so/hufsglobal/24482a1df32180ee9a69e00efb2d8ee4

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?