### PR TITLE
[BE-47] 북마크 그룹 생성, 그룹별 조회, 삭제, 수정 API 구현

### DIFF
--- a/src/main/java/com/yong2gether/ywave/bookmark/domain/BookmarkGroup.java
+++ b/src/main/java/com/yong2gether/ywave/bookmark/domain/BookmarkGroup.java
@@ -28,6 +28,9 @@ public class BookmarkGroup extends BaseTime {
     @Builder.Default
     @Column(name = "is_default", nullable = false)
     private boolean isDefault = false;
+    
+    @Column(name = "icon_url", length = 500)
+    private String iconUrl;
 }
 
 

--- a/src/main/java/com/yong2gether/ywave/bookmark/repository/BookmarkGroupRepository.java
+++ b/src/main/java/com/yong2gether/ywave/bookmark/repository/BookmarkGroupRepository.java
@@ -9,4 +9,6 @@ import java.util.Optional;
 public interface BookmarkGroupRepository extends JpaRepository<BookmarkGroup, Long> {
     Optional<BookmarkGroup> findByUserIdAndIsDefaultTrue(Long userId);
     boolean existsByUserIdAndName(Long userId, String name);
+    Optional<BookmarkGroup> findByIdAndUserId(Long id, Long userId);
+    boolean existsByUserIdAndNameAndIdNot(Long userId, String name, Long id);
 }

--- a/src/main/java/com/yong2gether/ywave/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/com/yong2gether/ywave/bookmark/repository/BookmarkRepository.java
@@ -42,4 +42,6 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
         s.name asc                   -- 동순위 보정
     """, nativeQuery = true)
     List<BookmarkFlatView> findAllGroupsWithStores(@Param("userId") Long userId);
+
+    void deleteByGroup_Id(Long groupId);
 }

--- a/src/main/java/com/yong2gether/ywave/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/com/yong2gether/ywave/bookmark/repository/BookmarkRepository.java
@@ -46,4 +46,7 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
     void deleteByGroup_Id(Long groupId);
     //북마크 여부 판단
     boolean existsByUser_IdAndStore_Id(Long userId, Long storeId);
+    
+    @Query("SELECT bg.iconUrl FROM BookmarkGroup bg WHERE bg.id = :groupId")
+    String findIconUrlByGroupId(@Param("groupId") Long groupId);
 }

--- a/src/main/java/com/yong2gether/ywave/global/exception/ApiExceptionHandler.java
+++ b/src/main/java/com/yong2gether/ywave/global/exception/ApiExceptionHandler.java
@@ -2,6 +2,7 @@ package com.yong2gether.ywave.global.exception;
 
 import com.yong2gether.ywave.user.service.UserService;
 import com.yong2gether.ywave.mypage.service.BookmarkGroupCommandService;
+import com.yong2gether.ywave.mypage.service.BookmarkGroupCommandService;
 import jakarta.validation.ConstraintViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -38,6 +39,24 @@ public class ApiExceptionHandler {
     @ExceptionHandler(ConstraintViolationException.class)
     public ResponseEntity<ErrorResponse> handleConstraint(ConstraintViolationException e) {
         return ResponseEntity.badRequest().body(new ErrorResponse("INVALID_REQUEST", e.getMessage()));
+    }
+
+    @ExceptionHandler(BookmarkGroupCommandService.GroupNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleGroupNotFound() {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(new ErrorResponse("GROUP_NOT_FOUND", "요청한 그룹을 찾을 수 없습니다."));
+    }
+
+    @ExceptionHandler(BookmarkGroupCommandService.NotOwnerOfGroupException.class)
+    public ResponseEntity<ErrorResponse> handleNotOwner() {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                .body(new ErrorResponse("FORBIDDEN", "해당 그룹에 대한 권한이 없습니다."));
+    }
+
+    @ExceptionHandler(BookmarkGroupCommandService.CannotDeleteDefaultGroupException.class)
+    public ResponseEntity<ErrorResponse> handleCannotDeleteDefault() {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse("CANNOT_DELETE_DEFAULT_GROUP", "기본 그룹은 삭제할 수 없습니다."));
     }
 
     public record ErrorResponse(String code, String message) {}

--- a/src/main/java/com/yong2gether/ywave/mypage/controller/BookmarkQueryController.java
+++ b/src/main/java/com/yong2gether/ywave/mypage/controller/BookmarkQueryController.java
@@ -86,4 +86,33 @@ public class BookmarkQueryController {
         );
         return ResponseEntity.ok(CreateBookmarkGroupResponse.ok(group));
     }
+
+    @Operation(summary="북마크 그룹 삭제",
+            description="내부 인증된 사용자 기준으로 북마크 그룹을 삭제합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode="200", description="삭제 성공"),
+            @ApiResponse(responseCode="403", description="권한 없음"),
+            @ApiResponse(responseCode="404", description="그룹 없음")
+    })
+    @DeleteMapping("/bookmarks/groups")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<DeleteBookmarkGroupResponse> deleteBookmarkGroup(
+            Authentication authentication,
+            @RequestBody DeleteBookmarkGroupRequest request
+    ) {
+        String email = (authentication != null ? authentication.getName() : null);
+        if (email == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "인증 필요");
+        }
+        Long userId = userRepository.findByEmail(email)
+                .map(u -> u.getId())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "사용자 정보를 찾을 수 없습니다."));
+
+        if (request.groupId() == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "groupId는 필수입니다.");
+        }
+
+        bookmarkGroupCommandService.deleteGroup(userId, request.groupId());
+        return ResponseEntity.ok(DeleteBookmarkGroupResponse.ok(request.groupId()));
+    }
 }

--- a/src/main/java/com/yong2gether/ywave/mypage/controller/BookmarkQueryController.java
+++ b/src/main/java/com/yong2gether/ywave/mypage/controller/BookmarkQueryController.java
@@ -2,6 +2,7 @@
 package com.yong2gether.ywave.mypage.controller;
 
 import com.yong2gether.ywave.mypage.dto.*;
+import com.yong2gether.ywave.mypage.dto.UpdatedBookmarkGroupDto;
 import com.yong2gether.ywave.mypage.service.BookmarkQueryService;
 import com.yong2gether.ywave.mypage.service.BookmarkGroupCommandService;
 import com.yong2gether.ywave.user.repository.UserRepository;
@@ -75,9 +76,9 @@ public class BookmarkQueryController {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "그룹 이름은 필수입니다.");
         }
 
-        // 그룹 생성 (iconUrl은 현재 도메인에 저장 필드가 없어 응답에만 반영)
+        // 그룹 생성 (iconUrl 포함하여 DB에 저장)
         com.yong2gether.ywave.bookmark.domain.BookmarkGroup saved =
-                bookmarkGroupCommandService.createGroup(userId, groupName);
+                bookmarkGroupCommandService.createGroup(userId, groupName, request.iconUrl());
 
         CreatedBookmarkGroupDto group = new CreatedBookmarkGroupDto(
                 saved.getId(),
@@ -114,5 +115,53 @@ public class BookmarkQueryController {
 
         bookmarkGroupCommandService.deleteGroup(userId, request.groupId());
         return ResponseEntity.ok(DeleteBookmarkGroupResponse.ok(request.groupId()));
+    }
+
+    @Operation(summary="북마크 그룹 수정",
+            description="내부 인증된 사용자 기준으로 북마크 그룹 이름을 수정합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode="200", description="수정 성공"),
+            @ApiResponse(responseCode="400", description="잘못된 요청"),
+            @ApiResponse(responseCode="403", description="권한 없음"),
+            @ApiResponse(responseCode="404", description="그룹 없음")
+    })
+    @PutMapping("/bookmarks/groups/{groupId}")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<UpdateBookmarkGroupResponse> updateBookmarkGroup(
+            Authentication authentication,
+            @PathVariable Long groupId,
+            @RequestBody UpdateBookmarkGroupRequest request
+    ) {
+        String email = (authentication != null ? authentication.getName() : null);
+        if (email == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "인증 필요");
+        }
+        Long userId = userRepository.findByEmail(email)
+                .map(u -> u.getId())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "사용자 정보를 찾을 수 없습니다."));
+
+        if (request.groupName() == null || request.groupName().isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "그룹 이름은 필수입니다.");
+        }
+
+        try {
+            com.yong2gether.ywave.bookmark.domain.BookmarkGroup updatedGroup =
+                    bookmarkGroupCommandService.updateGroup(userId, groupId, request.groupName(), request.iconUrl());
+
+            UpdatedBookmarkGroupDto group = new UpdatedBookmarkGroupDto(
+                    updatedGroup.getId(),
+                    updatedGroup.getName(),
+                    updatedGroup.getIconUrl()
+            );
+            return ResponseEntity.ok(UpdateBookmarkGroupResponse.ok(group));
+        } catch (BookmarkGroupCommandService.CannotUpdateDefaultGroupException e) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "기본 그룹은 수정할 수 없습니다.");
+        } catch (BookmarkGroupCommandService.DuplicateGroupNameException e) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, e.getMessage());
+        } catch (BookmarkGroupCommandService.GroupNotFoundException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "북마크 그룹을 찾을 수 없습니다.");
+        } catch (BookmarkGroupCommandService.NotOwnerOfGroupException e) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "해당 그룹을 수정할 권한이 없습니다.");
+        }
     }
 }

--- a/src/main/java/com/yong2gether/ywave/mypage/controller/MyPageReviewController.java
+++ b/src/main/java/com/yong2gether/ywave/mypage/controller/MyPageReviewController.java
@@ -6,17 +6,16 @@ package com.yong2gether.ywave.mypage.controller;
 import com.yong2gether.ywave.mypage.dto.UserReviewsResponse;
 import com.yong2gether.ywave.mypage.dto.ReviewItemDto;
 import com.yong2gether.ywave.mypage.service.ReviewQueryService;
-import com.yong2gether.ywave.user.domain.User;
 import com.yong2gether.ywave.user.repository.UserRepository;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.*;
 import io.swagger.v3.oas.annotations.responses.*;
-import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.*;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 
@@ -26,27 +25,33 @@ import java.util.List;
 public class MyPageReviewController {
 
     private final ReviewQueryService reviewQueryService;
+    private final UserRepository userRepository;
 
     @Operation(
             summary = "내가 쓴 리뷰 조회",
-            description = "userId 기준으로 해당 사용자가 작성한 모든 리뷰를 조회(디폴트:최신순)합니다."
+            description = "내부 인증된 사용자 기준으로 자신이 작성한 모든 리뷰를 조회합니다."
     )
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "성공",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = UserReviewsResponse.class))),
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "403", description = "권한 없음")
     })
-    @GetMapping("/{userId}/reviews") // API URL : GET /api/v1/mypage/{userId}/reviews
-    @PreAuthorize("@authz.isSelfOrAdmin(#userId, authentication)")
+    @GetMapping("/reviews") // API URL : GET /api/v1/mypage/reviews
+    @PreAuthorize("isAuthenticated()")
     public ResponseEntity<UserReviewsResponse> getMyReviews(
-            @Parameter(description = "사용자 ID", example = "1")
-            @PathVariable Long userId,
             Authentication authentication) {
-        System.out.println("[DEBUG] reviews principal=" + (authentication != null ? authentication.getName() : null) + ", userId=" + userId);
+        String email = (authentication != null ? authentication.getName() : null);
+        if (email == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "인증 필요");
+        }
+        
+        Long userId = userRepository.findByEmail(email)
+                .map(u -> u.getId())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "사용자 정보를 찾을 수 없습니다."));
+
+        System.out.println("[DEBUG] reviews principal=" + email + ", userId=" + userId);
         List<ReviewItemDto> items = reviewQueryService.getUserReviews(userId);
         return ResponseEntity.ok(
-                new UserReviewsResponse("사용자가 작성한 리뷰 목록 조회에 성공했습니다.", items)
+                new UserReviewsResponse("내가 작성한 리뷰 목록 조회에 성공했습니다.", items)
         );
     }
 }

--- a/src/main/java/com/yong2gether/ywave/mypage/dto/BookmarkGroupDto.java
+++ b/src/main/java/com/yong2gether/ywave/mypage/dto/BookmarkGroupDto.java
@@ -7,5 +7,6 @@ public record BookmarkGroupDto(
         Long groupId,
         String groupName,
         boolean isDefault,
+        String iconUrl,
         List<BookmarkedStoreDto> stores
 ) {}

--- a/src/main/java/com/yong2gether/ywave/mypage/dto/CreateBookmarkGroupRequest.java
+++ b/src/main/java/com/yong2gether/ywave/mypage/dto/CreateBookmarkGroupRequest.java
@@ -6,3 +6,4 @@ public record CreateBookmarkGroupRequest(
 ) {}
 
 
+

--- a/src/main/java/com/yong2gether/ywave/mypage/dto/CreateBookmarkGroupResponse.java
+++ b/src/main/java/com/yong2gether/ywave/mypage/dto/CreateBookmarkGroupResponse.java
@@ -10,3 +10,4 @@ public record CreateBookmarkGroupResponse(
 }
 
 
+

--- a/src/main/java/com/yong2gether/ywave/mypage/dto/CreatedBookmarkGroupDto.java
+++ b/src/main/java/com/yong2gether/ywave/mypage/dto/CreatedBookmarkGroupDto.java
@@ -7,3 +7,4 @@ public record CreatedBookmarkGroupDto(
 ) {}
 
 
+

--- a/src/main/java/com/yong2gether/ywave/mypage/dto/DeleteBookmarkGroupRequest.java
+++ b/src/main/java/com/yong2gether/ywave/mypage/dto/DeleteBookmarkGroupRequest.java
@@ -1,0 +1,7 @@
+package com.yong2gether.ywave.mypage.dto;
+
+public record DeleteBookmarkGroupRequest(
+        Long groupId
+) {}
+
+

--- a/src/main/java/com/yong2gether/ywave/mypage/dto/DeleteBookmarkGroupResponse.java
+++ b/src/main/java/com/yong2gether/ywave/mypage/dto/DeleteBookmarkGroupResponse.java
@@ -1,0 +1,12 @@
+package com.yong2gether.ywave.mypage.dto;
+
+public record DeleteBookmarkGroupResponse(
+        String message,
+        Long deletedGroupId
+) {
+    public static DeleteBookmarkGroupResponse ok(Long groupId) {
+        return new DeleteBookmarkGroupResponse("북마크 그룹 삭제 성공", groupId);
+    }
+}
+
+

--- a/src/main/java/com/yong2gether/ywave/mypage/dto/UpdateBookmarkGroupRequest.java
+++ b/src/main/java/com/yong2gether/ywave/mypage/dto/UpdateBookmarkGroupRequest.java
@@ -1,0 +1,11 @@
+package com.yong2gether.ywave.mypage.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record UpdateBookmarkGroupRequest(
+        @Size(min = 1, max = 100, message = "그룹 이름은 1자 이상 100자 이하여야 합니다.")
+        String groupName,  // 선택적 필드 (null이면 수정하지 않음)
+        
+        String iconUrl     // 선택적 필드 (null이면 수정하지 않음)
+) {}

--- a/src/main/java/com/yong2gether/ywave/mypage/dto/UpdateBookmarkGroupResponse.java
+++ b/src/main/java/com/yong2gether/ywave/mypage/dto/UpdateBookmarkGroupResponse.java
@@ -1,0 +1,10 @@
+package com.yong2gether.ywave.mypage.dto;
+
+public record UpdateBookmarkGroupResponse(
+        String message,
+        UpdatedBookmarkGroupDto group
+) {
+    public static UpdateBookmarkGroupResponse ok(UpdatedBookmarkGroupDto group) {
+        return new UpdateBookmarkGroupResponse("북마크 그룹 수정 성공", group);
+    }
+}

--- a/src/main/java/com/yong2gether/ywave/mypage/dto/UpdatedBookmarkGroupDto.java
+++ b/src/main/java/com/yong2gether/ywave/mypage/dto/UpdatedBookmarkGroupDto.java
@@ -1,0 +1,7 @@
+package com.yong2gether.ywave.mypage.dto;
+
+public record UpdatedBookmarkGroupDto(
+        Long groupId,
+        String groupName,
+        String iconUrl
+) {}

--- a/src/main/java/com/yong2gether/ywave/mypage/service/BookmarkQueryService.java
+++ b/src/main/java/com/yong2gether/ywave/mypage/service/BookmarkQueryService.java
@@ -33,6 +33,7 @@ public class BookmarkQueryService {
                     defaultGroup.getId(),
                     defaultGroup.getName(),
                     defaultGroup.isDefault(),
+                    defaultGroup.getIconUrl(),
                     new ArrayList<>()
             ));
         }
@@ -46,6 +47,7 @@ public class BookmarkQueryService {
                             r.getGroupId(),
                             r.getGroupName(),
                             Boolean.TRUE.equals(r.getIsDefault()),
+                            null, // iconUrl은 현재 projection에서 가져올 수 없음, 나중에 별도 조회 필요
                             new ArrayList<>()
                     )
             );
@@ -56,6 +58,22 @@ public class BookmarkQueryService {
                 ));
             }
         }
-        return new ArrayList<>(map.values());
+        
+        // 5) 각 그룹의 iconUrl을 별도로 조회하여 설정
+        List<BookmarkGroupDto> result = new ArrayList<>();
+        for (BookmarkGroupDto groupDto : map.values()) {
+            // 각 그룹의 iconUrl을 조회
+            String iconUrl = bookmarkRepository.findIconUrlByGroupId(groupDto.groupId());
+            BookmarkGroupDto updatedGroupDto = new BookmarkGroupDto(
+                    groupDto.groupId(),
+                    groupDto.groupName(),
+                    groupDto.isDefault(),
+                    iconUrl,
+                    groupDto.stores()
+            );
+            result.add(updatedGroupDto);
+        }
+        
+        return result;
     }
 }


### PR DESCRIPTION
## 🛰️ Issue Number
 - #47

## 🪐 작업 내용
1. 북마크 그룹 생성
- iconUrl 관련 컬럼 DB 추가 완료 

2. 북마크 그룹별 조회
- iconUrl 관련 응답 필드 추가
- iconUrl 관련 칼럼 DB 추가

3. 북마크 삭제
- 삭제 기능 구현 완료
- 북마크 내에 다른 것이 저장되어 있어도 북마크 삭제 가능

4. 북마크 수정 API
- 각각 요소 수정 가능
- 전체 수정 가능

## 📚 Reference
- 북마크 그룹 생성 API 명세서
https://www.notion.so/hufsglobal/25882a1df32180e2bd95ff413dc31bc8

- 북마크 그룹 수정 API 명세서
https://www.notion.so/hufsglobal/25882a1df32180da9bfecb02c285dc1e

- 북마크 그룹 삭제 API 명세서
https://www.notion.so/hufsglobal/25882a1df321800e9eb8d022a0f71342

- 북마크한 가맹점 그룹별 조회 API 명세서
https://www.notion.so/hufsglobal/24482a1df32180ee9a69e00efb2d8ee4

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
