### PR TITLE
Feat : 특정 그룹 북마크 상세 조회

### DIFF
--- a/src/main/java/com/yong2gether/ywave/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/com/yong2gether/ywave/bookmark/repository/BookmarkRepository.java
@@ -49,4 +49,7 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
     
     @Query("SELECT bg.iconUrl FROM BookmarkGroup bg WHERE bg.id = :groupId")
     String findIconUrlByGroupId(@Param("groupId") Long groupId);
+
+    @Query("SELECT b.store.id FROM Bookmark b WHERE b.group.id = :groupId")
+    List<Long> findStoreIdsByGroupId(@Param("groupId") Long groupId);
 }

--- a/src/main/java/com/yong2gether/ywave/mypage/controller/BookmarkQueryController.java
+++ b/src/main/java/com/yong2gether/ywave/mypage/controller/BookmarkQueryController.java
@@ -117,6 +117,31 @@ public class BookmarkQueryController {
         return ResponseEntity.ok(DeleteBookmarkGroupResponse.ok(request.groupId()));
     }
 
+    @Operation(summary="특정 그룹 북마크 상세 조회",
+            description="내부 인증된 사용자 기준으로 특정 그룹의 북마크 상세 정보를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode="200", description="조회 성공"),
+            @ApiResponse(responseCode="403", description="권한 없음"),
+            @ApiResponse(responseCode="404", description="그룹 없음")
+    })
+    @GetMapping("/bookmarks/{groupId}")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<BookmarkGroupDetailResponse> getBookmarkGroupDetail(
+            Authentication authentication,
+            @PathVariable Long groupId
+    ) {
+        String email = (authentication != null ? authentication.getName() : null);
+        if (email == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "인증 필요");
+        }
+        Long userId = userRepository.findByEmail(email)
+                .map(u -> u.getId())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "사용자 정보를 찾을 수 없습니다."));
+
+        BookmarkGroupDetailDto groupDetail = bookmarkQueryService.getBookmarkGroupDetail(userId, groupId);
+        return ResponseEntity.ok(BookmarkGroupDetailResponse.success(groupDetail));
+    }
+
     @Operation(summary="북마크 그룹 수정",
             description="내부 인증된 사용자 기준으로 북마크 그룹 이름을 수정합니다.")
     @ApiResponses({

--- a/src/main/java/com/yong2gether/ywave/mypage/dto/BookmarkGroupDetailDto.java
+++ b/src/main/java/com/yong2gether/ywave/mypage/dto/BookmarkGroupDetailDto.java
@@ -1,0 +1,11 @@
+package com.yong2gether.ywave.mypage.dto;
+
+import java.util.List;
+
+public record BookmarkGroupDetailDto(
+    Long groupId,
+    String groupName,
+    String iconUrl,
+    Boolean isDefault,
+    List<Long> stores
+) {}

--- a/src/main/java/com/yong2gether/ywave/mypage/dto/BookmarkGroupDetailResponse.java
+++ b/src/main/java/com/yong2gether/ywave/mypage/dto/BookmarkGroupDetailResponse.java
@@ -1,0 +1,13 @@
+package com.yong2gether.ywave.mypage.dto;
+
+public record BookmarkGroupDetailResponse(
+    String message,
+    BookmarkGroupDetailDto group
+) {
+    public static BookmarkGroupDetailResponse success(BookmarkGroupDetailDto group) {
+        return new BookmarkGroupDetailResponse(
+            "북마크 그룹 상세 조회 성공",
+            group
+        );
+    }
+}

--- a/src/main/java/com/yong2gether/ywave/mypage/service/BookmarkGroupCommandService.java
+++ b/src/main/java/com/yong2gether/ywave/mypage/service/BookmarkGroupCommandService.java
@@ -91,6 +91,11 @@ public class BookmarkGroupCommandService {
         groupRepo.delete(group);
     }
 
+    public BookmarkGroup getGroupById(Long groupId) {
+        return groupRepo.findById(groupId)
+                .orElseThrow(GroupNotFoundException::new);
+    }
+
     public static class GroupNotFoundException extends RuntimeException {}
     public static class NotOwnerOfGroupException extends RuntimeException {}
     public static class CannotDeleteDefaultGroupException extends RuntimeException {}

--- a/src/main/java/com/yong2gether/ywave/mypage/service/BookmarkQueryService.java
+++ b/src/main/java/com/yong2gether/ywave/mypage/service/BookmarkQueryService.java
@@ -10,6 +10,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.http.HttpStatus;
 
 @Service
 @RequiredArgsConstructor
@@ -75,5 +77,27 @@ public class BookmarkQueryService {
         }
         
         return result;
+    }
+
+    public BookmarkGroupDetailDto getBookmarkGroupDetail(Long userId, Long groupId) {
+        // 1) 그룹 정보 조회
+        BookmarkGroup group = bookmarkGroupCommandService.getGroupById(groupId);
+        
+        // 2) 사용자 권한 확인 (자신의 그룹만 조회 가능)
+        if (!group.getUser().getId().equals(userId)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "해당 그룹에 대한 접근 권한이 없습니다.");
+        }
+        
+        // 3) 해당 그룹의 가맹점 ID 목록 조회
+        List<Long> storeIds = bookmarkRepository.findStoreIdsByGroupId(groupId);
+        
+        // 4) DTO 생성 및 반환
+        return new BookmarkGroupDetailDto(
+            group.getId(),
+            group.getName(),
+            group.getIconUrl(),
+            group.isDefault(),
+            storeIds
+        );
     }
 }


### PR DESCRIPTION
## 🛰️ Issue Number
- #13 

## 🪐 작업 내용
- 특정 그룹의 북마크 상세 정보를 조회하는 API 구현
- 북마크 그룹별로 저장된 가맹점 리스트 조회 기능 추가
- 기존 북마크 시스템과 연동되도록 구조 설계
-  북마크 그룹 정보 (ID, 이름, 아이콘, 기본 그룹 여부)
- 해당 그룹에 저장된 가맹점 ID 리스트
- 사용자 권한 검증 (자신의 그룹만 조회 가능)

## 📚 Reference
- 특정 그룹 북마크 상세조회 API 명세서
https://www.notion.so/hufsglobal/25882a1df32180868154e5d7b39e0215

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
